### PR TITLE
add 'jp' to GeoSearchCountries

### DIFF
--- a/src/interface/geosearch.interface.ts
+++ b/src/interface/geosearch.interface.ts
@@ -76,6 +76,6 @@ export interface GeoSearchError extends Error {
   axiosResponse?: AxiosResponse;
 }
 
-export type GeoSearchCountries = 'cz' | 'sk' | 'de' | 'us' | 'gb';
+export type GeoSearchCountries = 'cz' | 'sk' | 'de' | 'us' | 'gb' | 'jp';
 
 export type GeoSearchScope = 'muni' | 'area' | 'pubt' | 'street';

--- a/src/utils/countries.ts
+++ b/src/utils/countries.ts
@@ -13,6 +13,8 @@ export function getCountryBounds(country: GeoSearchCountries | undefined): LatLn
       return { sw: { lat: 18.91619, lng: -171.791110603 }, ne: { lat: 71.3577635769, lng: -66.96466 } };
     case 'gb':
       return { sw: { lat: 49.959999905, lng: -7.57216793459 }, ne: { lat: 58.6350001085, lng: 1.68153079591 } };
+    case 'jp':
+      return { sw: { lat: 20.2531, lng: 122.5557 }, ne: { lat: 45.3326, lng: 153.5912 } };
     default:
       return null;
   }


### PR DESCRIPTION
Thank you for your nice software!

I'm going to use this library on my work which will be used mainly by Japanese.

So, I added a field `jp` to `GeoSearchContries`.

The country bounding which I added is based on [a data of Geospatial Information Authority of Japan](https://www.gsi.go.jp/KOKUJYOHO/center.htm).