### PR TITLE
add lang option to GeoSearchOptions (multi language support)

### DIFF
--- a/src/geosearch.ts
+++ b/src/geosearch.ts
@@ -8,7 +8,7 @@ export class GeoSearch {
     const bounds = await getBounds(options).catch(() => {
       throw createError('Input Error');
     });
-    const apiUrl = `${API_URL}?count=${COUNT}&phrase=${encodeURIComponent(query)}${bounds}`;
+    const apiUrl = `${API_URL}?count=${COUNT}&lang=${options?.lang}&phrase=${encodeURIComponent(query)}${bounds}`;
 
     // For debugging
     if (options?.debug) {

--- a/src/interface/geosearch.interface.ts
+++ b/src/interface/geosearch.interface.ts
@@ -64,6 +64,7 @@ export interface GeoSearchOptions {
   bounds?: LatLngBounds;
   country?: GeoSearchCountries;
   debug?: boolean;
+  lang?: "en" | "cs" | "de" | "pl" | "sk" | "ru" | "es" | "fr";
 }
 
 export type GeoSearchErrorMessage = 'Error' | 'Network Error' | 'Input Error' | 'API request failed';

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -25,3 +25,11 @@ test('Non existing place', async () => {
   });
   expect(places.length).toBe(0);
 });
+
+test('Show result in German', async () => {
+  const places = await geoSearch.suggest('Kyoto tower', {
+    country: 'jp',
+    lang: 'de'
+  });
+  expect(places[0].userData.suggestSecondRow).toBe('Touristenattraktion, Kyōto - Shimogyō-ku, Japan');
+});


### PR DESCRIPTION
Hi, thanks for your nice software!

I want to get the search result in English not only in Czech.

I read [Mapy.cz Suggest API's document](https://api.mapy.cz/doc/SMap.Suggest.html) and I found that the API support multi language output such as English(en), Czech(cs), German(de), Polish(pl), Slovak(sk), Russian(ru), Spanish(es) and French(fr).

So I added `lang` option to `GeoSearchOptions`. Users can show result in a language which they prefer.

And, this option is also optional. So this PR is not breaking change.

```javascript
geoSearch.suggest("Kyoto tower", {
    lang: "en" // "en" | "cs" | "de" | "pl" | "sk" | "ru" | "es" | "fr"
}).then(result => {
    console.log(result); // returns search results in English
})
```